### PR TITLE
Fix issue when where plugin can't be activated

### DIFF
--- a/class-style-connection.php
+++ b/class-style-connection.php
@@ -1,6 +1,6 @@
 <?php
 
-class StyleConnectionResolver extends WPGraphQL\Data\Connection\AbstractConnectionResolver
+abstract class StyleConnectionResolver extends WPGraphQL\Data\Connection\AbstractConnectionResolver
 {
 
   public function get_items()


### PR DESCRIPTION
Resolve [500 error in WPGQL v0.6.1](https://github.com/emaildano/wp-graphql-enqueue/issues/1)